### PR TITLE
Updated to spring-boot 1.4.0-RELEASE and spring-session-1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,19 +28,19 @@ repositories {
 
 dependencies {
 
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter', version: '1.3.2.RELEASE'
-    compile('org.springframework.data:spring-data-couchbase:2.0.0.RELEASE') {
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter', version: '1.4.0.RELEASE'
+    compile('org.springframework.data:spring-data-couchbase:2.1.2.RELEASE') {
         exclude group: 'org.springframework', module: 'spring-web'
     }
-    compile group: 'org.springframework.session', name: 'spring-session', version: '1.1.0.RELEASE'
+    compile group: 'org.springframework.session', name: 'spring-session', version: '1.2.2.RELEASE'
     compile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.1-1'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
 
-    compile group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: '1.3.2.RELEASE', optional
+    compile group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: '1.4.0.RELEASE', optional
 
-    testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '1.3.2.RELEASE'
-    testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '1.3.2.RELEASE'
+    testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '1.4.0.RELEASE'
+    testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '1.4.0.RELEASE'
     testCompile group: 'org.spockframework', name: 'spock-spring', version: '1.0-groovy-2.4'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Fri Feb 05 17:41:33 CET 2016
+#Fri Sep 09 10:34:20 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/github/mkopylec/sessioncouchbase/persistent/CouchbaseSession.java
+++ b/src/main/java/com/github/mkopylec/sessioncouchbase/persistent/CouchbaseSession.java
@@ -60,12 +60,12 @@ public class CouchbaseSession implements ExpiringSession, Serializable {
 
     @Override
     public long getCreationTime() {
-        return round((double) globalAttributes.get(CREATION_TIME_ATTRIBUTE));
+        return ((Number)globalAttributes.get(CREATION_TIME_ATTRIBUTE)).longValue();
     }
 
     @Override
     public long getLastAccessedTime() {
-        return round((double) globalAttributes.get(LAST_ACCESSED_TIME_ATTRIBUTE));
+        return ((Number)globalAttributes.get(LAST_ACCESSED_TIME_ATTRIBUTE)).longValue();
     }
 
     public void setLastAccessedTime(long lastAccessedTime) {

--- a/src/test/java/com/github/mkopylec/sessioncouchbase/TestApplication.java
+++ b/src/test/java/com/github/mkopylec/sessioncouchbase/TestApplication.java
@@ -1,11 +1,13 @@
 package com.github.mkopylec.sessioncouchbase;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
 
 import static org.springframework.boot.SpringApplication.run;
 
 @EnableCouchbaseHttpSession
 @SpringBootApplication
+@Import(TestConfiguration.class)
 public class TestApplication {
 
     public static void main(String[] args) {

--- a/src/test/java/com/github/mkopylec/sessioncouchbase/TestConfiguration.java
+++ b/src/test/java/com/github/mkopylec/sessioncouchbase/TestConfiguration.java
@@ -1,0 +1,31 @@
+package com.github.mkopylec.sessioncouchbase;
+
+import org.apache.catalina.Context;
+import org.apache.tomcat.util.http.LegacyCookieProcessor;
+import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
+import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
+import org.springframework.boot.context.embedded.tomcat.TomcatContextCustomizer;
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TestConfiguration {
+
+    @Bean
+    public EmbeddedServletContainerCustomizer customizer() {
+        return new EmbeddedServletContainerCustomizer() {
+            @Override
+            public void customize(ConfigurableEmbeddedServletContainer container) {
+                TomcatEmbeddedServletContainerFactory tomcat = (TomcatEmbeddedServletContainerFactory) container;
+                tomcat.addContextCustomizers(
+                        new TomcatContextCustomizer() {
+                            @Override
+                            public void customize(Context context) {
+                                context.setCookieProcessor(new LegacyCookieProcessor());
+                            }
+                        });
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fixed problem with embedded tomcat cookie checking update to rfc6265 on tests (https://github.com/spring-projects/spring-boot/issues/6827)
Fixed Object to double cast exception
