### PR TITLE
Take bucket name from CouchbaseTemplate

### DIFF
--- a/src/main/java/com/github/mkopylec/sessioncouchbase/configuration/PersistentConfiguration.java
+++ b/src/main/java/com/github/mkopylec/sessioncouchbase/configuration/PersistentConfiguration.java
@@ -26,8 +26,6 @@ import java.util.Map;
 public class PersistentConfiguration {
 
     @Autowired
-    protected CouchbaseProperties couchbase;
-    @Autowired
     protected SessionCouchbaseProperties sessionCouchbase;
 
     @Bean
@@ -51,6 +49,6 @@ public class PersistentConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public SessionDao sessionDao(CouchbaseTemplate couchbaseTemplate, @Qualifier("sessionCouchbaseRetryTemplate") RetryTemplate retryTemplate) {
-        return new PersistentDao(couchbase, sessionCouchbase, couchbaseTemplate, retryTemplate);
+        return new PersistentDao(sessionCouchbase, couchbaseTemplate, retryTemplate);
     }
 }

--- a/src/main/java/com/github/mkopylec/sessioncouchbase/data/PersistentDao.java
+++ b/src/main/java/com/github/mkopylec/sessioncouchbase/data/PersistentDao.java
@@ -33,8 +33,8 @@ public class PersistentDao implements SessionDao {
     protected final CouchbaseTemplate couchbaseTemplate;
     protected final RetryTemplate retryTemplate;
 
-    public PersistentDao(CouchbaseProperties couchbase, SessionCouchbaseProperties sessionCouchbase, CouchbaseTemplate couchbaseTemplate, RetryTemplate retryTemplate) {
-        bucket = couchbase.getBucket().getName();
+    public PersistentDao(SessionCouchbaseProperties sessionCouchbase, CouchbaseTemplate couchbaseTemplate, RetryTemplate retryTemplate) {
+        bucket = couchbaseTemplate.getCouchbaseBucket().name();
         queryConsistency = sessionCouchbase.getPersistent().getQueryConsistency();
         this.couchbaseTemplate = couchbaseTemplate;
         this.retryTemplate = retryTemplate;


### PR DESCRIPTION
An instance of CouchbaseProperties is not needed to retrieve the bucket name.
By taking it from the CouchbaseTemplate we are not forced to have a CouchbaseProperties bean in the context.